### PR TITLE
Added fetching user public events

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -38,10 +38,11 @@ jobs:
       - name: "Install dependencies"
         run: "composer install --no-interaction --no-progress --no-suggest"
 
-      - name: "Run Aggregations"
+      - name: "Fetch Data & Run Aggregations"
         run: |
             bin/gh fetch:pull-requests flow-php flow
             bin/gh fetch:commits flow-php flow
+            bin/gh fetch:user:events:public norberttech
             bin/gh aggregate:contributions flow-php flow
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/bin/gh
+++ b/bin/gh
@@ -36,6 +36,12 @@ return function (array $context) {
         )
     );
     $app->add(
+        new Command\Fetch\UserPublicEventsCommand(
+            $kernel->getContainer()->getParameter('gh.token'),
+            $kernel->getContainer()->getParameter('data.warehouse.dir'),
+        )
+    );
+    $app->add(
         new Command\Aggregate\ContributionsCommand(
             $kernel->getContainer()->getParameter('data.warehouse.dir'),
             $kernel->getContainer()->getParameter('kernel.project_dir').'/templates',

--- a/src/Command/Fetch/CommitsCommand.php
+++ b/src/Command/Fetch/CommitsCommand.php
@@ -122,7 +122,7 @@ class CommitsCommand extends Command
                     Expression::on(['sha' => 'sha'], 'details_')
                 )
                 ->partitionBy(ref('date_utc'), ref('pr'))
-                ->write(to_json(rtrim($this->warehousePath, '/')."/{$org}/{$repository}/commit"))
+                ->write(to_json(rtrim($this->warehousePath, '/')."/repo/{$org}/{$repository}/commit"))
                 // Execute
                 ->run();
         }

--- a/src/Dataset/Contributions/DataFrameFactory/ContributionsFactory.php
+++ b/src/Dataset/Contributions/DataFrameFactory/ContributionsFactory.php
@@ -27,7 +27,7 @@ final class ContributionsFactory implements DataFrameFactory
         $end = new \DateTimeImmutable($rows->sortBy(ref('date_utc')->asc())->reverse()->first()->valueOf('date_utc'));
 
         return (new Flow())
-            ->read(Json::from(rtrim($this->warehousePath, '/')."/{$this->org}/{$this->repository}/commit/date_utc=*/pr=*/*"))
+            ->read(Json::from(rtrim($this->warehousePath, '/')."/repo/{$this->org}/{$this->repository}/commit/date_utc=*/pr=*/*"))
             ->filterPartitions(
                 new CallableFilter(
                     function (Partition $partition) use ($start, $end): bool {

--- a/src/Dataset/Contributions/TopContributors.php
+++ b/src/Dataset/Contributions/TopContributors.php
@@ -32,7 +32,7 @@ final class TopContributors
     public function contributor(int $year, string $login): array
     {
         $rows = (new Flow())
-            ->read(CSV::from($this->warehousePath."/{$this->org}/{$this->repository}/report/".$year.'/top_contributors.csv'))
+            ->read(CSV::from($this->warehousePath."/repo/{$this->org}/{$this->repository}/report/".$year.'/top_contributors.csv'))
             ->filter(ref('user_login')->lower()->equals(lit(\mb_strtolower($login))))
             ->fetch(1);
 

--- a/src/Dataset/PullRequests/PullRequests.php
+++ b/src/Dataset/PullRequests/PullRequests.php
@@ -2,9 +2,10 @@
 
 namespace App\Dataset\PullRequests;
 
-use Flow\ETL\DSL\Json;
 use Flow\ETL\Partition\CallableFilter;
 use Flow\ETL\{Flow, Partition};
+
+use function Flow\ETL\Adapter\JSON\from_json;
 
 final class PullRequests
 {
@@ -18,7 +19,7 @@ final class PullRequests
     public function between(\DateTimeInterface $afterDate, \DateTimeInterface $beforeDate): \Generator
     {
         return (new Flow())
-            ->read(Json::from(rtrim($this->warehousePath, '/')."/{$this->org}/{$this->repository}/pr/date_utc=*/*"))
+            ->read(from_json(rtrim($this->warehousePath, '/')."/repo/{$this->org}/{$this->repository}/pr/date_utc=*/*"))
             ->filterPartitions(
                 new CallableFilter(
                     fn (Partition $partition) => new \DateTimeImmutable($partition->value) >= $afterDate && new \DateTimeImmutable($partition->value) <= $beforeDate

--- a/src/Factory/GitHub/UserPublicEventsFactory.php
+++ b/src/Factory/GitHub/UserPublicEventsFactory.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factory\GitHub;
+
+use Flow\ETL\Adapter\Http\DynamicExtractor\NextRequestFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message;
+
+final class UserPublicEventsFactory implements NextRequestFactory
+{
+    public function __construct(
+        private readonly string $token,
+        private readonly string $username,
+        private readonly Psr17Factory $factory = new Psr17Factory()
+    ) {
+    }
+
+    public function create(Message\ResponseInterface $previousResponse = null): ?Message\RequestInterface
+    {
+        if ($previousResponse instanceof Message\ResponseInterface) {
+            if (false === $previousResponse->hasHeader('link')) {
+                return null;
+            }
+
+            $paginationLinkHeaders = $this->parsePaginationLinkHeader($previousResponse->getHeaderLine('link'));
+
+            if (isset($paginationLinkHeaders['next'])) {
+                return $this->factory->createRequest('GET', $paginationLinkHeaders['next'])
+                    ->withHeader('Accept', 'application/vnd.github+json')
+                    ->withHeader('Authorization', 'Bearer '.$this->token)
+                    ->withHeader('X-GitHub-Api-Version', '2022-11-28')
+                    ->withHeader('User-Agent', 'flow-gh-api-fetch');
+            }
+
+            return null;
+        }
+
+        return $this->factory
+            ->createRequest('GET', "https://api.github.com/users/{$this->username}/events/public?per_page=100&page=1")
+            ->withHeader('Accept', 'application/vnd.github+json')
+            ->withHeader('Authorization', 'Bearer '.$this->token)
+            ->withHeader('X-GitHub-Api-Version', '2022-11-28')
+            ->withHeader('User-Agent', 'flow-gh-api-fetch');
+    }
+
+    private function parsePaginationLinkHeader(string $headerLink): array
+    {
+        $availableLinks = [];
+        $links = explode(',', $headerLink);
+
+        foreach ($links as $link) {
+            if (preg_match('/<(.*)>;\srel=\\"(.*)\\"/', $link, $matches)) {
+                $availableLinks[$matches[2]] = $matches[1];
+            }
+        }
+
+        return $availableLinks;
+    }
+}


### PR DESCRIPTION
This PR brings fetching users public events. It also moves repo related datasets under `/repo/{org}/{reponame}` folder, previously it was `{org}/{reponame}`. User events are saved in `/user/{username}` 